### PR TITLE
remove unneeded classes

### DIFF
--- a/check-in-policies.html
+++ b/check-in-policies.html
@@ -132,13 +132,13 @@ A helper element for defining a check-in policy
         <div class="row">
           <div class="form-group col-md-6">
             <label for="instructions" class="required">Instructions</label>
-            <iron-autogrow-textarea id="instructions" class="form-control"
+            <iron-autogrow-textarea id="instructions"
                                     bind-value="{{item.instructions}}" rows="2"
                                     max-rows="6"></iron-autogrow-textarea>
           </div>
           <div class="form-group col-md-6">
             <label for="addendum" class="required">Addendum</label>
-            <iron-autogrow-textarea id="addendum" class="form-control"
+            <iron-autogrow-textarea id="addendum"
                                     bind-value="{{item.addendum}}" rows="2"
                                     max-rows="6"></iron-autogrow-textarea>
           </div>

--- a/ll-property-information-edit.html
+++ b/ll-property-information-edit.html
@@ -41,10 +41,6 @@ The `ll-property-information-edit` handles creating and editing of property info
       cursor: text;
     }
 
-    iron-autogrow-textarea {
-      height: auto;
-    }
-
     .entypo {
       font-size: 3em;
       vertical-align: middle;


### PR DESCRIPTION
remove form-control class from iron-autogrow-textarea since it now uses ll-theme shared-styles
