### PR TITLE
Adding Delete functionality

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -29,7 +29,8 @@
       get-url="http://www.google.com/"
       edit-url="#"
       create-url="#"
-      mode="edit"></ll-property-information>
+      mode="edit"
+      can-delete></ll-property-information>
 </div>
 
 <script>
@@ -84,6 +85,10 @@
   function logData() {
     console.log(propertyInfo._property);
   }
+
+  document.addEventListener('ll-property-information-edit-delete-property', function(e) {
+    console.log('Event to Delete: ', e.detail);
+  });
 
 </script>
 

--- a/ll-property-information-edit.html
+++ b/ll-property-information-edit.html
@@ -60,6 +60,13 @@ The `ll-property-information-edit` handles creating and editing of property info
       margin-right: 15px;
     }
 
+    .actions #delete-property {
+      display: none;
+    }
+    :host.can-delete .actions #delete-property {
+      display: inline-block;
+    }
+
     .checkbox {
       margin-top: 5px;
     }
@@ -291,6 +298,7 @@ The `ll-property-information-edit` handles creating and editing of property info
 
             <template is="dom-if" if="{{isEdit}}" restamp>
               <button type="button" class="btn btn-link" on-tap="_editCancelClicked">Cancel</button>
+              <button type="button" id="delete-property" on-tap="_deletePropertyClicked" class="btn btn-destructive">Delete Property</button>
               <button type="submit" class="btn btn-primary">Save Changes</button>
             </template>
 
@@ -313,12 +321,13 @@ The `ll-property-information-edit` handles creating and editing of property info
     LLPropertyInformationEdit = Polymer({
       is: 'll-property-information-edit',
 
-      factoryImpl: function (property, isEdit) {
+      factoryImpl: function (property, isEdit, canDelete) {
         if (!property && isEdit) {
           throw new Error('Cannot be in edit mode without a property supplied');
         }
         if (property) this.property = property;
         this.isEdit = isEdit || false;
+        this.canDelete = canDelete || false;
       },
 
       attached: function () {
@@ -352,6 +361,14 @@ The `ll-property-information-edit` handles creating and editing of property info
        * @property {Object} property - The property being mutated
        */
 
+      /**
+       * Fired when Delete button is clicked on edit form
+       *
+       * @event ll-property-information-edit-delete-property
+       * @type
+       * @property {Object} property - The property to be deleted
+       */
+
       properties: {
         /**
          * Default value is not set here because _initProperty method is called on ready
@@ -361,6 +378,13 @@ The `ll-property-information-edit` handles creating and editing of property info
          */
         property: {
           type: Object
+        },
+        /**
+         * Boolean flag that is used to show or hide the delete button on the Edit Page
+         */
+        canDelete: {
+          type:Boolean,
+          value: false
         },
         /**
          * Whether or not the view should render in edit mode from the @prop property
@@ -413,6 +437,7 @@ The `ll-property-information-edit` handles creating and editing of property info
       _initForm: function () {
         this.$['available-input'].checked = this.property.isAvailableForBooking;
         this.$['post-form'].onsubmit = this._handlePost.bind(this);
+        this.toggleClass('can-delete', this.canDelete);
 
         var self = this;
 
@@ -473,6 +498,12 @@ The `ll-property-information-edit` handles creating and editing of property info
           throw new Error('Cannot view create mode when not in edit mode');
         }
         this.fire('ll-property-information-edit-create-property');
+      },
+      _deletePropertyClicked: function() {
+        if (!this.isEdit) {
+          throw new Error('Cannot delete a property when not in edit mode');
+        }
+        this.fire('ll-property-information-edit-delete-property', {unitId: this.property.unitId});
       },
       _postCreateClicked: function () {
         if (this.isEdit) {

--- a/ll-property-information.html
+++ b/ll-property-information.html
@@ -30,7 +30,7 @@ Example
     </template>
 
     <template is="dom-if" id="view-mode" if="{{_inEditMode}}" restamp>
-      <ll-property-information-edit property="{{_property}}" is-edit></ll-property-information-edit>
+      <ll-property-information-edit property="{{_property}}" is-edit can-delete="{{canDelete}}"></ll-property-information-edit>
     </template>
 
     <template is="dom-if" id="create-mode" if="{{_inCreateMode}}" restamp>
@@ -137,6 +137,13 @@ Example
         mode: {
           type: String,
           value: 'view'
+        },
+        /**
+         * Boolean flag that is used to show or hide the delete button on the Edit Page
+         */
+        canDelete: {
+          type: Boolean,
+          value: false
         },
         _property: {
           type: Object,

--- a/test/ll-property-information-edit-test.html
+++ b/test/ll-property-information-edit-test.html
@@ -66,7 +66,15 @@
       describe('view', function() {
 
         it('should have 4 action elements for buttons and dom-if templates', function() {
-          expect(myEl.$$('.actions').children).to.have.length(4);
+          expect(myEl.$$('.actions').children).to.have.length(5);
+        });
+
+        it('should be created with the Delete button hidden by default', function() {
+          expect(myEl.canDelete).to.be.false;
+        });
+
+        it('should hide the Delete button if canDelete is false', function() {
+          expect(getComputedStyle(myEl.$$('#delete-property')).display).to.be.eql('none');
         });
 
       });
@@ -139,6 +147,71 @@
           }).to.throw(/Cannot post create in edit mode/);
         });
 
+      });
+    });
+
+    describe('Edit Mode - Can Delete', function() {
+      var property = {
+        name: '7858 Aster Lane',
+        isAvailableForBooking: true,
+        buildingCategory: 'condo',
+        buildingType: 'townhome',
+        geoLocation: {
+          latitude: 49.235,
+          longitude: 23.246
+        },
+        bedroomCount: 5,
+        bathroomCount: 5,
+        fullBathrooms: 3,
+        threeQuarterBathrooms: 0,
+        halfBathrooms: 2,
+        occupancy: 12,
+        description: 'This should be a long description but nah',
+        amenities: ['fireplace', 'jacuzzi', 'steam shower'],
+        address: {
+          address1: '7857 Aster Lane',
+          address2: '',
+          city: 'Park City',
+          stateCode: 'UT',
+          postalCode: '84060',
+          countyCode: 'US'
+        },
+        currencyCode: 'USD',
+        checkInInformationRanges: [{
+          startDate:'2015-02-01T00:00:00Z',
+          endDate:'2015-02-28T00:00:00Z'
+        },{
+          startDate:'2015-05-01T00:00:00Z',
+          endDate:'2015-06-01T00:00:00Z'
+        },{
+          startDate:'2015-03-01T00:00:00Z',
+          endDate:'2015-04-01T00:00:00Z'
+        }],
+        unitId: '311_xxx'
+      };
+
+      var myEl = new LLPropertyInformationEdit(property, true, true);
+      document.body.appendChild(myEl);
+
+      describe('delete enabled', function() {
+
+
+        it('should be created with the canDelete property set to true', function() {
+          expect(myEl.canDelete).to.be.true;
+        });
+
+        it('should show the Delete button', function() {
+          expect(getComputedStyle(myEl.$$('#delete-property')).display).to.be.eql('inline-block');
+        });
+
+        it('should raise an event when the Delete button is clicked', function(done) {
+          myEl.addEventListener('ll-property-information-edit-delete-property', function(event) {
+            expect(event.detail).to.have.property('unitId', '311_xxx');
+            done();
+          });
+
+          myEl._deletePropertyClicked();
+        });
       });
     });
 


### PR DESCRIPTION
# What does this PR do?
- This PR adds a way for the ll-property-information component to be displayed with a Delete button. This button will only be available to Admin Users in the IH application, and it will have server side auth checks to make sure that only Admins can actually delete a property. The property will also be soft-deleted on the server side, so we will still retain data.
### Where should the reviewer start?
- Look at the code
- Polyserve it, adjust the demo to have the can-delete attribute or remove it.
- Run the tests.
### Any background context you want to provide?
- This goes along with a series of other PRs on the Pmc-API, Pmc-Client, and Units-manager to enable the soft delete functionality. There will still need to be additional changes in the Integration Hub to determine when to show the button, and to handle the event and process the delete.
### What are the relevant tickets?

https://vacationroost.atlassian.net/browse/IH-1196
