### PR TITLE
remove ll-unit-id from view

### DIFF
--- a/ll-property-information-view.html
+++ b/ll-property-information-view.html
@@ -142,14 +142,6 @@ Example:
         </p>
       </ll-definition-list>
 
-      <!--<ll-definition-list title="CURRENCY:" hidden$="{{!property.currencyCode}}">-->
-        <!--<p>{{property.currencyCode}}</p>-->
-      <!--</ll-definition-list>-->
-
-      <!--<ll-definition-list title="LL UNIT ID:" hidden$="{{!property.unitId}}">-->
-        <!--<p>{{property.unitId}}</p>-->
-      <!--</ll-definition-list>-->
-
     </div>
 
     <hr/>

--- a/ll-property-information-view.html
+++ b/ll-property-information-view.html
@@ -146,9 +146,9 @@ Example:
         <!--<p>{{property.currencyCode}}</p>-->
       <!--</ll-definition-list>-->
 
-      <ll-definition-list title="LL UNIT ID:" hidden$="{{!property.unitId}}">
-        <p>{{property.unitId}}</p>
-      </ll-definition-list>
+      <!--<ll-definition-list title="LL UNIT ID:" hidden$="{{!property.unitId}}">-->
+        <!--<p>{{property.unitId}}</p>-->
+      <!--</ll-definition-list>-->
 
     </div>
 


### PR DESCRIPTION
commented out the ll-unit-id so it doesn't display in property info tab
